### PR TITLE
Add setup script

### DIFF
--- a/.agent/setup.sh
+++ b/.agent/setup.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Install packages needed to build and test bcachefs-tools
+sudo apt-get update
+sudo apt-get install -y \
+    pkg-config libaio-dev libblkid-dev libkeyutils-dev liblz4-dev \
+    libsodium-dev liburcu-dev libzstd-dev uuid-dev zlib1g-dev \
+    valgrind libudev-dev udev git build-essential python3 \
+    python3-docutils libclang-dev debhelper dh-python systemd-dev \
+    libscrypt-dev libfuse3-dev
+
+# Install a recent Rust toolchain if rustup is not present
+if ! command -v rustup >/dev/null 2>&1; then
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \
+        sh -s -- -y --no-modify-path
+    source "$HOME/.cargo/env"
+fi

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,8 @@ compile_commands.json
 !.github/dependabot.yml
 !.github/workflows/
 !.editorconfig
+!.agent/
+!.agent/*
 
 bcachefs-principles-of-operation.*
 


### PR DESCRIPTION
## Summary
- provide `.agent/setup.sh` with dependencies for building and testing
- update `.gitignore` to allow the `.agent` directory

## Testing
- `make -j 4`
- `cargo test --no-run`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_684e58a2d7e88320855d2d263651bc38