### PR TITLE
Add setup script for building and testing

### DIFF
--- a/.agent/setup.sh
+++ b/.agent/setup.sh
@@ -1,17 +1,16 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Install packages needed to build and test bcachefs-tools
+# Install packages required for building and testing bcachefs-tools
 sudo apt-get update
-sudo apt-get install -y \
-    pkg-config libaio-dev libblkid-dev libkeyutils-dev liblz4-dev \
+sudo apt-get install -y --no-install-recommends \
+    build-essential git pkg-config python3 \
+    libaio-dev libblkid-dev libkeyutils-dev liblz4-dev \
     libsodium-dev liburcu-dev libzstd-dev uuid-dev zlib1g-dev \
-    valgrind libudev-dev udev git build-essential python3 \
-    python3-docutils libclang-dev debhelper dh-python systemd-dev \
-    libscrypt-dev libfuse3-dev
+    libudev-dev libclang-dev
 
-# Install a recent Rust toolchain if rustup is not present
-if ! command -v rustup >/dev/null 2>&1; then
+# Install a recent Rust toolchain if rustup/cargo are missing
+if ! command -v cargo >/dev/null 2>&1; then
     curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \
         sh -s -- -y --no-modify-path
     source "$HOME/.cargo/env"


### PR DESCRIPTION
## Summary
- add a minimal `.agent/setup.sh` for installing build and test dependencies

## Testing
- `./.agent/setup.sh`
- `make -j$(nproc)`
- `cargo test --no-run`


------
https://chatgpt.com/codex/tasks/task_e_684e5ea5ab108320a7edc08bdfe36665