### PR TITLE
Fix cargo tests by building libbcachefs

### DIFF
--- a/.agent/setup.sh
+++ b/.agent/setup.sh
@@ -15,3 +15,6 @@ if ! command -v cargo >/dev/null 2>&1; then
         sh -s -- -y --no-modify-path
     source "$HOME/.cargo/env"
 fi
+
+# Build the C library required by Rust tests
+make libbcachefs.a


### PR DESCRIPTION
## Summary
- build libbcachefs in setup so rust tests can link

## Testing
- `cargo test --locked`

------
https://chatgpt.com/codex/tasks/task_e_684e6c93b068832089556a5973bc75e5